### PR TITLE
WIP: Workflow Execution Schema

### DIFF
--- a/src/main/resources/swagger/ga4gh-workflow-execution.yaml
+++ b/src/main/resources/swagger/ga4gh-workflow-execution.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   version: 1.0.0
-  title: Compute Service API
+  title: CWL workflow execution service API
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
@@ -135,7 +135,7 @@ paths:
           description: Job ID
           required: true
       responses:
-        '200':
+        '204':
           description: Job deleted
         '404':
           description: Job not found

--- a/src/main/resources/swagger/ga4gh-workflow-execution.yaml
+++ b/src/main/resources/swagger/ga4gh-workflow-execution.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   version: 1.0.0
-  title: CWL workflow execution service API
+  title: GA4GH workflow execution service API
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
@@ -18,7 +18,7 @@ paths:
       parameters:
         - in: body
           name: body
-          description: Input binding for cwl workflow.
+          description: Input binding for workflow.
           required: true
           schema:
             $ref: '#/definitions/job-description'
@@ -217,7 +217,7 @@ paths:
         '404':
           description: Job not found
 definitions:
-  cwl-binding:
+  workflow-binding:
     type: object
     additionalProperties: true
   job-description:
@@ -236,7 +236,7 @@ definitions:
         description: location of the workflow
         example: https://github.com/common-workflow-language/common-workflow-language/raw/master/v1.0/v1.0/wc-tool.cwl
       input:
-        $ref: '#/definitions/cwl-binding'
+        $ref: '#/definitions/workflow-binding'
     example:
       name: myjob1
       workflow: https://github.com/common-workflow-language/common-workflow-language/raw/master/v1.0/v1.0/wc-tool.cwl
@@ -269,7 +269,7 @@ definitions:
         description: location of the workflow
         example: https://github.com/common-workflow-language/common-workflow-language/raw/master/v1.0/v1.0/wc-tool.cwl
       input:
-        $ref: '#/definitions/cwl-binding'
+        $ref: '#/definitions/workflow-binding'
       state:
         type: string
         enum:
@@ -282,7 +282,7 @@ definitions:
           - PermanentFailure
         example: Running
       output:
-        $ref: '#/definitions/cwl-binding'
+        $ref: '#/definitions/workflow-binding'
       log:
         type: string
         format: uri

--- a/src/main/resources/swagger/ga4gh-workflow-execution.yaml
+++ b/src/main/resources/swagger/ga4gh-workflow-execution.yaml
@@ -82,6 +82,7 @@ paths:
                 workflow: https://github.com/common-workflow-language/common-workflow-language/raw/master/v1.0/v1.0/wc-tool.cwl
   '/jobs/{jobId}':
     get:
+      summary: Get a job
       operationId: getJobById
       parameters:
         - name: jobId
@@ -106,7 +107,7 @@ paths:
                     "location": "whale.txt"
                   }
                 },
-                "log": "http://localhost:5000/jobs/afcd1554-9604-11e6-bd3f-080027e8b32a/stderr",
+                "log": "http://localhost:5000/jobs/afcd1554-9604-11e6-bd3f-080027e8b32a/log",
                 "name": "myjob1",
                 "output": {
                       "output": {
@@ -124,6 +125,8 @@ paths:
         '404':
           description: Job not found
     delete:
+      summary: Deleta a job
+      description: Delete a job, if job is in waiting or running state then job will be cancelled first.
       operationId: deleteJobById
       parameters:
         - name: jobId
@@ -133,11 +136,12 @@ paths:
           required: true
       responses:
         '200':
-          description: Job deleted (will cancel if still running)
+          description: Job deleted
         '404':
           description: Job not found
   '/jobs/{jobId}/cancel':
     post:
+      summary: Cancel a job
       operationId: cancelJobById
       parameters:
         - name: jobId
@@ -147,7 +151,69 @@ paths:
           required: true
       responses:
         '200':
-          description: Job cancelled if still running
+          description: Job has been cancelled if job was still running or waiting
+          schema:
+            $ref: '#/definitions/job'
+          headers:
+            Location:
+              description: uri of the cancelled job
+              type: string
+              format: uri
+          examples:
+            'application/json':
+              {
+                "id": "afcd1554-9604-11e6-bd3f-080027e8b32a",
+                "input": {
+                   "file1": {
+                    "class": "File",
+                    "location": "whale.txt"
+                  }
+                },
+                "log": "http://localhost:5000/jobs/afcd1554-9604-11e6-bd3f-080027e8b32a/log",
+                "name": "myjob1",
+                "output": {
+                      "output": {
+                      "checksum": "sha1$6f9bd042bff934443cc65f7ef769613222f7b136",
+                      "basename": "output",
+                      "location": "file:///tmp/afcd1554-9604-11e6-bd3f-080027e8b32a/output",
+                      "path": "/tmp/afcd1554-9604-11e6-bd3f-080027e8b32a/output",
+                      "class": "File",
+                      "size": 9
+                  }
+                },
+                "state": "Cancelled",
+                "workflow": "https://github.com/common-workflow-language/common-workflow-language/raw/master/v1.0/v1.0/wc-tool.cwl"
+              }
+        '404':
+          description: Job not found
+  '/jobs/{jobId}/log':
+    get:
+      summary: Log of a job
+      operationId: getJobLogById
+      produces:
+        - text/plain
+      parameters:
+        - name: jobId
+          in: path
+          type: string
+          description: Job ID
+          required: true
+      responses:
+        '200':
+          description: Job log
+          schema:
+            type: string
+        '302':
+          description: Job log redirect
+          headers:
+            Location:
+              description: uri of the log of the job
+              type: string
+              format: uri
+          examples:
+            'text/plain': |
+              [job wc-tool.cwl] /tmp/afcd1554-9604-11e6-bd3f-080027e8b32a$ wc < /tmp/afcd1554-9604-11e6-bd3f-080027e8b32a/stge84d1078-e33f-41c3-8714-aafe955d1b53/whale.txt > /tmp/afcd1554-9604-11e6-bd3f-080027e8b32a/output
+              Final process status is success
         '404':
           description: Job not found
 definitions:
@@ -220,3 +286,4 @@ definitions:
       log:
         type: string
         format: uri
+        example: http://localhost:5000/jobs/afcd1554-9604-11e6-bd3f-080027e8b32a/log

--- a/src/main/resources/swagger/ga4gh-workflow-execution.yaml
+++ b/src/main/resources/swagger/ga4gh-workflow-execution.yaml
@@ -2,11 +2,15 @@ swagger: '2.0'
 info:
   version: 1.0.0
   title: Compute Service API
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 paths:
   /jobs:
     post:
       summary: submit a new job
       description: Submit a new job from a workflow definition.
+      operationId: postJob
       consumes:
         - application/json
       produces:
@@ -15,6 +19,7 @@ paths:
         - in: body
           name: body
           description: Input binding for cwl workflow.
+          required: true
           schema:
             $ref: '#/definitions/job-description'
       responses:
@@ -27,9 +32,28 @@ paths:
               description: uri of the created job
               type: string
               format: uri
+          examples:
+            'application/json':
+              {
+                "id": "afcd1554-9604-11e6-bd3f-080027e8b32a",
+                "input": {
+                   "file1": {
+                    "class": "File",
+                    "location": "whale.txt"
+                  }
+                },
+                "log": "http://localhost:5000/jobs/afcd1554-9604-11e6-bd3f-080027e8b32a/log",
+                "name": "myjob1",
+                "output": {},
+                "state": "Running",
+                "workflow": "https://github.com/common-workflow-language/common-workflow-language/raw/master/v1.0/v1.0/wc-tool.cwl"
+              }
     get:
       summary: list of jobs
       description: 'get a list of all jobs, running, cancelled, or otherwise.'
+      operationId: getJobs
+      produces:
+        - application/json
       responses:
         '200':
           description: list of jobs
@@ -37,20 +61,70 @@ paths:
             type: array
             items:
               $ref: '#/definitions/job'
+          examples:
+            'application/json':
+              - id: afcd1554-9604-11e6-bd3f-080027e8b32a
+                input:
+                   file1:
+                    class: File
+                    location: whale.txt
+                log: http://localhost:5000/jobs/afcd1554-9604-11e6-bd3f-080027e8b32a/stderr
+                name: myjob1
+                output:
+                  output:
+                    checksum: sha1$6f9bd042bff934443cc65f7ef769613222f7b136
+                    basename: output
+                    location: file:///tmp/afcd1554-9604-11e6-bd3f-080027e8b32a/output
+                    path: /tmp/afcd1554-9604-11e6-bd3f-080027e8b32a/output
+                    class: File
+                    size: 9
+                state: Success
+                workflow: https://github.com/common-workflow-language/common-workflow-language/raw/master/v1.0/v1.0/wc-tool.cwl
   '/jobs/{jobId}':
     get:
+      operationId: getJobById
       parameters:
         - name: jobId
           in: path
           type: string
           description: Job ID
           required: true
+      produces:
+        - application/json
       responses:
         '200':
           description: Status of job
           schema:
             $ref: '#/definitions/job'
+          examples:
+            'application/json':
+              {
+                "id": "afcd1554-9604-11e6-bd3f-080027e8b32a",
+                "input": {
+                   "file1": {
+                    "class": "File",
+                    "location": "whale.txt"
+                  }
+                },
+                "log": "http://localhost:5000/jobs/afcd1554-9604-11e6-bd3f-080027e8b32a/stderr",
+                "name": "myjob1",
+                "output": {
+                      "output": {
+                      "checksum": "sha1$6f9bd042bff934443cc65f7ef769613222f7b136",
+                      "basename": "output",
+                      "location": "file:///tmp/afcd1554-9604-11e6-bd3f-080027e8b32a/output",
+                      "path": "/tmp/afcd1554-9604-11e6-bd3f-080027e8b32a/output",
+                      "class": "File",
+                      "size": 9
+                  }
+                },
+                "state": "Success",
+                "workflow": "https://github.com/common-workflow-language/common-workflow-language/raw/master/v1.0/v1.0/wc-tool.cwl"
+              }
+        '404':
+          description: Job not found
     delete:
+      operationId: deleteJobById
       parameters:
         - name: jobId
           in: path
@@ -60,8 +134,11 @@ paths:
       responses:
         '200':
           description: Job deleted (will cancel if still running)
+        '404':
+          description: Job not found
   '/jobs/{jobId}/cancel':
     post:
+      operationId: cancelJobById
       parameters:
         - name: jobId
           in: path
@@ -71,6 +148,8 @@ paths:
       responses:
         '200':
           description: Job cancelled if still running
+        '404':
+          description: Job not found
 definitions:
   cwl-binding:
     type: object
@@ -84,12 +163,21 @@ definitions:
       name:
         type: string
         description: user supplied (non unique) name for this job
+        example: myjob1
       workflow:
         type: string
         format: uri
         description: location of the workflow
+        example: https://github.com/common-workflow-language/common-workflow-language/raw/master/v1.0/v1.0/wc-tool.cwl
       input:
         $ref: '#/definitions/cwl-binding'
+    example:
+      name: myjob1
+      workflow: https://github.com/common-workflow-language/common-workflow-language/raw/master/v1.0/v1.0/wc-tool.cwl
+      input:
+        file1:
+          class: File
+          location: whale.txt
   job:
     type: object
     required:
@@ -104,13 +192,16 @@ definitions:
       id:
         type: string
         format: uri
+        example: afcd1554-9604-11e6-bd3f-080027e8b32a
       name:
         type: string
         description: user supplied (non unique) name for this job
+        example: myjob1
       workflow:
         type: string
         format: uri
         description: location of the workflow
+        example: https://github.com/common-workflow-language/common-workflow-language/raw/master/v1.0/v1.0/wc-tool.cwl
       input:
         $ref: '#/definitions/cwl-binding'
       state:
@@ -123,6 +214,7 @@ definitions:
           - SystemError
           - TemporaryFailure
           - PermanentFailure
+        example: Running
       output:
         $ref: '#/definitions/cwl-binding'
       log:

--- a/src/main/resources/swagger/ga4gh-workflow-execution.yaml
+++ b/src/main/resources/swagger/ga4gh-workflow-execution.yaml
@@ -1,0 +1,138 @@
+swagger: '2.0'
+info:
+  version: 1.0.0
+  title: Compute Service API
+paths:
+  /:
+    get:
+      summary: 'Check if the server is working at all, returns some status info.'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: OK
+  /jobs:
+    post:
+      summary: submit a new job
+      description: Submit a new job from a workflow definition.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: Input binding for cwl workflow.
+          schema:
+            $ref: '#/definitions/job-description'
+      responses:
+        '201':
+          description: OK
+          schema:
+            $ref: '#/definitions/job'
+          headers:
+            Location:
+              description: uri of the created job
+              type: string
+              format: uri
+    get:
+      summary: list of jobs
+      description: 'get a list of all jobs, running, cancelled, or otherwise.'
+      responses:
+        '200':
+          description: list of jobs
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/job'
+  '/jobs/{jobId}':
+    get:
+      parameters:
+        - name: jobId
+          in: path
+          type: string
+          description: Job ID
+          required: true
+      responses:
+        '200':
+          description: Status of job
+          schema:
+            $ref: '#/definitions/job'
+    delete:
+      parameters:
+        - name: jobId
+          in: path
+          type: string
+          description: Job ID
+          required: true
+      responses:
+        '200':
+          description: Job deleted (will cancel if still running)
+  '/jobs/{jobId}/cancel':
+    post:
+      parameters:
+        - name: jobId
+          in: path
+          type: string
+          description: Job ID
+          required: true
+      responses:
+        '200':
+          description: Job cancelled if still running
+definitions:
+  cwl-binding:
+    type: object
+    additionalProperties: true
+  job-description:
+    type: object
+    required:
+      - workflow
+    additionalProperties: false
+    properties:
+      name:
+        type: string
+        description: user supplied (non unique) name for this job
+      workflow:
+        type: string
+        format: uri
+        description: location of the workflow
+      input:
+        $ref: '#/definitions/cwl-binding'
+  job:
+    type: object
+    required:
+      - id
+      - name
+      - workflow
+      - input
+      - state
+      - output
+      - log
+    properties:
+      id:
+        type: string
+        format: uri
+      name:
+        type: string
+        description: user supplied (non unique) name for this job
+      workflow:
+        type: string
+        format: uri
+        description: location of the workflow
+      input:
+        $ref: '#/definitions/cwl-binding'
+      state:
+        type: string
+        enum:
+          - Waiting
+          - Running
+          - Success
+          - Cancelled
+          - SystemError
+          - TemporaryFailure
+          - PermanentFailure
+      output:
+        $ref: '#/definitions/cwl-binding'
+      log:
+        type: string
+        format: uri


### PR DESCRIPTION
Hello,

As we needed a way to run CWL using a rest API, we've created a scheme based on the [cwltool-service](https://github.com/common-workflow-language/cwltool-service). As @tetron suggested this could be usefull for the ga4gh community, I made this into a pull request here.

Note that this scheme is close but not identical to the cwltool-service. Biggest difference is the absence of the "pause" state, for which we could not think up an actual use case, nor a sane implementation. We would be happy to hear your thoughts on this.

To test this scheme we also forked [cwltool-service](https://github.com/NLeSC/cwltool-service), and altered the implementation to use connexion.

All work in progress, but I wanted to let you know we are working on this and get your feedback.